### PR TITLE
Fix changeMessageVisibility

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -269,7 +269,7 @@ class Client {
   changeMessageVisibility(queueName, receiptHandle, visibilityTimeout) {
     const url = `/queues/${queueName}/messages?` +
       `receiptHandle=${receiptHandle}&visibilityTimeout=${visibilityTimeout}`;
-    return this.put(url, 'ChangeVisibility');
+    return this.put(url, 'ChangeVisibility', '');
   }
 
   // Topic


### PR DESCRIPTION
The `buildHeaders`method request that `body` must be a string or buffer. Before the fix, `changeMessageVisibility` method always throw error `TypeError: Data must be a string or a buffer`. After the fix, the `changeMessageVisibility` method works fine.